### PR TITLE
Fixes the order of binding sound devices upon resume

### DIFF
--- a/profiles/devices/acer-c720/system/etc/pm/sleep.d/05_sound
+++ b/profiles/devices/acer-c720/system/etc/pm/sleep.d/05_sound
@@ -12,8 +12,8 @@ case "${1}" in
 		# Bind ehci for preventing error
 		echo -n "0000:00:1d.0" | tee /sys/bus/pci/drivers/ehci-pci/bind
 		# Bind snd_hda_intel for sound
-		echo -n "0000:00:1b.0" | tee /sys/bus/pci/drivers/snd_hda_intel/bind
 		echo -n "0000:00:03.0" | tee /sys/bus/pci/drivers/snd_hda_intel/bind
+		echo -n "0000:00:1b.0" | tee /sys/bus/pci/drivers/snd_hda_intel/bind
 	;;
 
 esac


### PR DESCRIPTION
This fixes an issue which affects HP Chromebook 14 devices. After resume, sound was not available.  Changing the ordering here seems to resolve the problem.
